### PR TITLE
Sponsors Partners Block Implementation

### DIFF
--- a/src/blocks/RenderBlocks.tsx
+++ b/src/blocks/RenderBlocks.tsx
@@ -7,6 +7,7 @@ import { CallToActionBlock } from '@/blocks/CallToAction/Component'
 import { ContentBlock } from '@/blocks/Content/Component'
 import { FormBlock } from '@/blocks/Form/Component'
 import { MediaBlock } from '@/blocks/MediaBlock/Component'
+import { SponsorsPartnersBlock } from '@/blocks/SponsorsPartners/Component'
 
 const blockComponents = {
   archive: ArchiveBlock,
@@ -14,6 +15,7 @@ const blockComponents = {
   cta: CallToActionBlock,
   formBlock: FormBlock,
   mediaBlock: MediaBlock,
+  sponsorsPartners: SponsorsPartnersBlock,
 }
 
 export const RenderBlocks: React.FC<{
@@ -30,12 +32,11 @@ export const RenderBlocks: React.FC<{
           const { blockType } = block
 
           if (blockType && blockType in blockComponents) {
-            const Block = blockComponents[blockType]
+            const Block = blockComponents[blockType] as React.ComponentType<any>
 
             if (Block) {
               return (
                 <div className="my-16" key={index}>
-                  {/* @ts-expect-error there may be some mismatch between the expected types here */}
                   <Block {...block} disableInnerContainer />
                 </div>
               )

--- a/src/blocks/SponsorsPartners/Component.tsx
+++ b/src/blocks/SponsorsPartners/Component.tsx
@@ -1,0 +1,77 @@
+'use client'
+
+import { Media } from '@/components/Media'
+import type { Media as MediaDoc } from '@/payload-types'
+import React from 'react'
+
+type Logo = { media?: MediaDoc | string; alt?: string; href?: string }
+type Section = { heading?: string; logos?: Logo[] }
+
+type Props = {
+  title?: string
+  caption?: string
+  sponsors?: Section
+  partners?: Section
+}
+
+export const SponsorsPartnersBlock: React.FC<Props> = ({ title, caption, sponsors, partners }) => {
+  const renderSection = (section?: Section) => {
+    if (!section?.logos?.length) return null
+
+    return (
+      <section className="container my-12">
+        {section.heading && (
+          <h2 className="mb-3 text-center text-2xl md:text-3xl font-semibold tracking-tight">
+            {section.heading}
+          </h2>
+        )}
+
+        {/* 4 logos per row from sm+; 2 per row on very small screens */}
+        <div className="grid grid-cols-2 sm:grid-cols-4 gap-x-10 gap-y-8 items-center justify-items-center">
+          {section.logos!.map((item, i) => {
+            const doc =
+              item.media && typeof item.media === 'object' ? (item.media as MediaDoc) : undefined
+
+            const node = doc ? (
+              <Media resource={doc} imgClassName="max-h-20 md:max-h-24 w-auto object-contain" />
+            ) : (
+              <img
+                src={typeof item.media === 'string' ? item.media : ''}
+                alt={item.alt || ''}
+                className="max-h-20 md:max-h-24 w-auto object-contain"
+              />
+            )
+
+            return item.href ? (
+              <a key={i} href={item.href} target="_blank" rel="noreferrer">
+                {node}
+              </a>
+            ) : (
+              <div key={i}>{node}</div>
+            )
+          })}
+        </div>
+      </section>
+    )
+  }
+
+  return (
+    // use site tokens so it inherits theme (light/dark) + fonts
+    <div className="bg-background text-foreground py-16">
+      <div className="container text-center">
+        {/* match heading style used elsewhere */}
+        {title && <h1 className="text-3xl md:text-4xl font-semibold tracking-tight">{title}</h1>}
+
+        {/* subtitle/caption uses the muted token */}
+        {caption && <p className="mt-2 text-muted-foreground">{caption}</p>}
+      </div>
+
+      {renderSection(sponsors)}
+
+      {/* divider uses the global border token */}
+      <div className="container my-10 h-px bg-border" />
+
+      {renderSection(partners)}
+    </div>
+  )
+}

--- a/src/blocks/SponsorsPartners/Component.tsx
+++ b/src/blocks/SponsorsPartners/Component.tsx
@@ -5,18 +5,16 @@ import type { Media as MediaDoc } from '@/payload-types'
 import React from 'react'
 
 type Logo = { media?: MediaDoc | string; alt?: string; href?: string }
-type Section = { heading?: string; logos?: Logo[] }
+type Section = { heading?: string; description?: string; logos?: Logo[] }
 
 type Props = {
-  title?: string
-  caption?: string
   sponsors?: Section
   partners?: Section
 }
 
-export const SponsorsPartnersBlock: React.FC<Props> = ({ title, caption, sponsors, partners }) => {
+export const SponsorsPartnersBlock: React.FC<Props> = ({ sponsors, partners }) => {
   const renderSection = (section?: Section) => {
-    if (!section?.logos?.length) return null
+    if (!section || !(section.heading || section.description || section.logos?.length)) return null
 
     return (
       <section className="container my-12">
@@ -24,6 +22,10 @@ export const SponsorsPartnersBlock: React.FC<Props> = ({ title, caption, sponsor
           <h2 className="mb-3 text-center text-2xl md:text-3xl font-semibold tracking-tight">
             {section.heading}
           </h2>
+        )}
+
+        {section.description && (
+          <p className="mb-6 text-center text-muted-foreground">{section.description}</p>
         )}
 
         {/* 4 logos per row from sm+; 2 per row on very small screens */}
@@ -56,21 +58,8 @@ export const SponsorsPartnersBlock: React.FC<Props> = ({ title, caption, sponsor
   }
 
   return (
-    // use site tokens so it inherits theme (light/dark) + fonts
-    <div className="bg-background text-foreground py-16">
-      <div className="container text-center">
-        {/* match heading style used elsewhere */}
-        {title && <h1 className="text-3xl md:text-4xl font-semibold tracking-tight">{title}</h1>}
-
-        {/* subtitle/caption uses the muted token */}
-        {caption && <p className="mt-2 text-muted-foreground">{caption}</p>}
-      </div>
-
+    <div className="py-12">
       {renderSection(sponsors)}
-
-      {/* divider uses the global border token */}
-      <div className="container my-10 h-px bg-border" />
-
       {renderSection(partners)}
     </div>
   )

--- a/src/blocks/SponsorsPartners/config.ts
+++ b/src/blocks/SponsorsPartners/config.ts
@@ -1,0 +1,45 @@
+import type { Block } from 'payload'
+
+export const SponsorsPartners: Block = {
+  slug: 'sponsorsPartners',
+  labels: { singular: 'Sponsors/Partners', plural: 'Sponsors/Partners' },
+  fields: [
+    { name: 'title', type: 'text', required: true },
+    { name: 'caption', type: 'textarea' },
+    {
+      type: 'group',
+      name: 'sponsors',
+      label: 'Sponsors Section',
+      fields: [
+        { name: 'heading', type: 'text', defaultValue: 'Sponsors' },
+        {
+          name: 'logos',
+          type: 'array',
+          fields: [
+            { name: 'media', type: 'upload', relationTo: 'media', required: true },
+            { name: 'alt', type: 'text' },
+            { name: 'href', type: 'text' },
+          ],
+        },
+      ],
+    },
+    {
+      type: 'group',
+      name: 'partners',
+      label: 'Partners Section',
+      fields: [
+        { name: 'heading', type: 'text', defaultValue: 'Partners' },
+        {
+          name: 'logos',
+          type: 'array',
+          fields: [
+            { name: 'media', type: 'upload', relationTo: 'media', required: true },
+            { name: 'alt', type: 'text' },
+            { name: 'href', type: 'text' },
+          ],
+        },
+      ],
+    },
+  ],
+}
+export default SponsorsPartners

--- a/src/blocks/SponsorsPartners/config.ts
+++ b/src/blocks/SponsorsPartners/config.ts
@@ -4,14 +4,13 @@ export const SponsorsPartners: Block = {
   slug: 'sponsorsPartners',
   labels: { singular: 'Sponsors/Partners', plural: 'Sponsors/Partners' },
   fields: [
-    { name: 'title', type: 'text', required: true },
-    { name: 'caption', type: 'textarea' },
     {
       type: 'group',
       name: 'sponsors',
       label: 'Sponsors Section',
       fields: [
         { name: 'heading', type: 'text', defaultValue: 'Sponsors' },
+        { name: 'description', type: 'textarea', label: 'Caption' },
         {
           name: 'logos',
           type: 'array',
@@ -29,6 +28,7 @@ export const SponsorsPartners: Block = {
       label: 'Partners Section',
       fields: [
         { name: 'heading', type: 'text', defaultValue: 'Partners' },
+        { name: 'description', type: 'textarea', label: 'Caption' },
         {
           name: 'logos',
           type: 'array',

--- a/src/collections/Pages/index.ts
+++ b/src/collections/Pages/index.ts
@@ -12,6 +12,7 @@ import { slugField } from '@/fields/slug'
 import { populatePublishedAt } from '../../hooks/populatePublishedAt'
 import { generatePreviewPath } from '../../utilities/generatePreviewPath'
 import { revalidateDelete, revalidatePage } from './hooks/revalidatePage'
+import { SponsorsPartners } from '../../blocks/SponsorsPartners/config'
 
 import {
   MetaDescriptionField,
@@ -75,7 +76,7 @@ export const Pages: CollectionConfig<'pages'> = {
             {
               name: 'layout',
               type: 'blocks',
-              blocks: [CallToAction, Content, MediaBlock, Archive, FormBlock],
+              blocks: [CallToAction, Content, MediaBlock, Archive, FormBlock, SponsorsPartners],
               required: true,
               admin: {
                 initCollapsed: true,

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -196,7 +196,42 @@ export interface Page {
       | null;
     media?: (string | null) | Media;
   };
-  layout: (CallToActionBlock | ContentBlock | MediaBlock | ArchiveBlock | FormBlock)[];
+  layout: (
+    | CallToActionBlock
+    | ContentBlock
+    | MediaBlock
+    | ArchiveBlock
+    | FormBlock
+    | {
+        title: string;
+        caption?: string | null;
+        sponsors?: {
+          heading?: string | null;
+          logos?:
+            | {
+                media: string | Media;
+                alt?: string | null;
+                href?: string | null;
+                id?: string | null;
+              }[]
+            | null;
+        };
+        partners?: {
+          heading?: string | null;
+          logos?:
+            | {
+                media: string | Media;
+                alt?: string | null;
+                href?: string | null;
+                id?: string | null;
+              }[]
+            | null;
+        };
+        id?: string | null;
+        blockName?: string | null;
+        blockType: 'sponsorsPartners';
+      }
+  )[];
   meta?: {
     title?: string | null;
     /**
@@ -1037,6 +1072,40 @@ export interface PagesSelect<T extends boolean = true> {
         mediaBlock?: T | MediaBlockSelect<T>;
         archive?: T | ArchiveBlockSelect<T>;
         formBlock?: T | FormBlockSelect<T>;
+        sponsorsPartners?:
+          | T
+          | {
+              title?: T;
+              caption?: T;
+              sponsors?:
+                | T
+                | {
+                    heading?: T;
+                    logos?:
+                      | T
+                      | {
+                          media?: T;
+                          alt?: T;
+                          href?: T;
+                          id?: T;
+                        };
+                  };
+              partners?:
+                | T
+                | {
+                    heading?: T;
+                    logos?:
+                      | T
+                      | {
+                          media?: T;
+                          alt?: T;
+                          href?: T;
+                          id?: T;
+                        };
+                  };
+              id?: T;
+              blockName?: T;
+            };
       };
   meta?:
     | T

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -204,10 +204,9 @@ export interface Page {
     | ArchiveBlock
     | FormBlock
     | {
-        title: string;
-        caption?: string | null;
         sponsors?: {
           heading?: string | null;
+          description?: string | null;
           logos?:
             | {
                 media: string | Media;
@@ -219,6 +218,7 @@ export interface Page {
         };
         partners?: {
           heading?: string | null;
+          description?: string | null;
           logos?:
             | {
                 media: string | Media;
@@ -1093,12 +1093,11 @@ export interface PagesSelect<T extends boolean = true> {
         sponsorsPartners?:
           | T
           | {
-              title?: T;
-              caption?: T;
               sponsors?:
                 | T
                 | {
                     heading?: T;
+                    description?: T;
                     logos?:
                       | T
                       | {
@@ -1112,6 +1111,7 @@ export interface PagesSelect<T extends boolean = true> {
                 | T
                 | {
                     heading?: T;
+                    description?: T;
                     logos?:
                       | T
                       | {


### PR DESCRIPTION
Created Sponsors Partners Block that can be added if a user on the admin dashboard navigates to Pages to resolve issue #6 .
<img width="1510" height="978" alt="Screenshot 2025-09-22 at 2 45 48 PM" src="https://github.com/user-attachments/assets/b24148d3-bdcf-4095-8725-e01758a3d3f8" />

Above image shows the page where admins can add a Sponsors Partners block.

<img width="1512" height="982" alt="Screenshot 2025-09-22 at 2 48 07 PM" src="https://github.com/user-attachments/assets/d1daa396-9432-41a6-a8e4-597fc34c9105" />

Above Image is an example of what a page could look like with this block>
