### PR TITLE
feat/gallery-block

### DIFF
--- a/src/app/(frontend)/globals.css
+++ b/src/app/(frontend)/globals.css
@@ -89,7 +89,7 @@
     @apply border-border;
   }
   body {
-    @apply bg-background text-foreground min-h-[100vh] flex flex-col;
+    @apply bg-white text-foreground min-h-[100vh] flex flex-col;
   }
 }
 

--- a/src/blocks/Gallery/Component.tsx
+++ b/src/blocks/Gallery/Component.tsx
@@ -1,0 +1,240 @@
+'use client'
+
+import React, { useState } from 'react'
+import { cn } from '@/utilities/ui'
+import { Media } from '@/components/Media'
+import { ChevronLeft, ChevronRight, X, Play } from 'lucide-react'
+
+import type { Gallery as GalleryProps } from '@/payload-types'
+
+type Props = GalleryProps & {
+  className?: string
+  enableGutter?: boolean
+  disableInnerContainer?: boolean
+}
+
+export const Gallery: React.FC<Props> = (props) => {
+  const { title, images, className, enableGutter = true, disableInnerContainer } = props
+
+  const [selectedImageIndex, setSelectedImageIndex] = useState<number | null>(null)
+
+  const openModal = (index: number) => {
+    setSelectedImageIndex(index)
+  }
+
+  const closeModal = () => {
+    setSelectedImageIndex(null)
+  }
+
+  const goToPrevious = () => {
+    if (selectedImageIndex !== null && images) {
+      setSelectedImageIndex(selectedImageIndex > 0 ? selectedImageIndex - 1 : images.length - 1)
+    }
+  }
+
+  const goToNext = () => {
+    if (selectedImageIndex !== null && images) {
+      setSelectedImageIndex(selectedImageIndex < images.length - 1 ? selectedImageIndex + 1 : 0)
+    }
+  }
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Escape') {
+      closeModal()
+    } else if (e.key === 'ArrowLeft') {
+      goToPrevious()
+    } else if (e.key === 'ArrowRight') {
+      goToNext()
+    }
+  }
+
+  if (!images || images.length === 0) {
+    return null
+  }
+
+  // Helper function to check if media is a video
+  const isVideo = (media: any) => {
+    return typeof media === 'object' && media?.mimeType?.includes('video')
+  }
+
+  return (
+    <>
+      <div
+        className={cn(
+          'py-16',
+          {
+            container: enableGutter,
+          },
+          className,
+        )}
+      >
+        {/* Gallery Title */}
+        {title && (
+          <div
+            className={cn('mb-12 text-center', {
+              container: !disableInnerContainer,
+            })}
+          >
+            <h2 className="text-4xl font-bold text-black">{title}</h2>
+          </div>
+        )}
+
+        {/* Gallery Grid */}
+        <div
+          className={cn('columns-1 gap-6 space-y-6 md:columns-2 lg:columns-3 xl:columns-4', {
+            container: !disableInnerContainer,
+          })}
+        >
+          {images.map((item, index) => {
+            if (typeof item.media === 'object' && item.media !== null) {
+              const mediaIsVideo = isVideo(item.media)
+
+              return (
+                <div
+                  key={index}
+                  className="group relative cursor-pointer overflow-hidden rounded-2xl bg-gray-100 transition-transform duration-300 hover:scale-105 break-inside-avoid mb-6"
+                  onClick={() => openModal(index)}
+                >
+                  <div className="relative">
+                    {mediaIsVideo ? (
+                      // For videos, show a thumbnail/poster image with play button
+                      <div className="relative">
+                        <video
+                          className="w-full h-auto object-cover rounded-2xl"
+                          muted
+                          playsInline
+                          preload="metadata"
+                        >
+                          <source
+                            src={
+                              typeof item.media === 'object' && item.media?.url
+                                ? item.media.url
+                                : ''
+                            }
+                          />
+                        </video>
+                        <div className="absolute inset-0 bg-black bg-opacity-0 transition-all duration-300 group-hover:bg-opacity-20 rounded-2xl" />
+                        <div className="absolute inset-0 flex items-center justify-center">
+                          <div className="bg-black/50 rounded-full p-4 transition-transform duration-300 group-hover:scale-110">
+                            <Play className="w-8 h-8 text-white fill-white" />
+                          </div>
+                        </div>
+                      </div>
+                    ) : (
+                      // For images, use the Media component as before
+                      <>
+                        <Media
+                          resource={item.media}
+                          imgClassName="w-full h-auto object-cover transition-transform duration-300 group-hover:scale-110 rounded-2xl"
+                        />
+                        <div className="absolute inset-0 bg-black bg-opacity-0 transition-all duration-300 group-hover:bg-opacity-20 rounded-2xl" />
+                      </>
+                    )}
+                  </div>
+                  {item.caption && (
+                    <div className="absolute bottom-0 left-0 right-0 bg-gradient-to-t from-black/70 to-transparent p-4 text-white opacity-0 transition-opacity duration-300 group-hover:opacity-100 rounded-b-2xl">
+                      <p className="text-sm">{item.caption}</p>
+                    </div>
+                  )}
+                </div>
+              )
+            }
+            return null
+          })}
+        </div>
+      </div>
+
+      {/* Modal */}
+      {selectedImageIndex !== null && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-95"
+          onClick={closeModal}
+          onKeyDown={handleKeyDown}
+          tabIndex={0}
+          role="dialog"
+          aria-modal="true"
+        >
+          {/* Modal Content */}
+          <div
+            className="relative max-h-[90vh] max-w-[90vw] p-4"
+            onClick={(e) => e.stopPropagation()}
+          >
+            {/* Close Button */}
+            <button
+              className="absolute -top-12 right-0 text-white hover:text-gray-300 transition-colors z-10 bg-black/50 rounded-full p-2"
+              onClick={closeModal}
+              aria-label="Close modal"
+            >
+              <X size={24} />
+            </button>
+
+            {/* Navigation Arrows */}
+            {images && images.length > 1 && (
+              <>
+                <button
+                  className="absolute left-4 top-1/2 -translate-y-1/2 text-white hover:text-gray-300 transition-colors z-10 bg-black/50 rounded-full p-2"
+                  onClick={goToPrevious}
+                  aria-label="Previous image"
+                >
+                  <ChevronLeft size={32} />
+                </button>
+
+                <button
+                  className="absolute right-4 top-1/2 -translate-y-1/2 text-white hover:text-gray-300 transition-colors z-10 bg-black/50 rounded-full p-2"
+                  onClick={goToNext}
+                  aria-label="Next image"
+                >
+                  <ChevronRight size={32} />
+                </button>
+              </>
+            )}
+
+            {/* Media (Image or Video) */}
+            <div className="relative">
+              {typeof images[selectedImageIndex]?.media === 'object' &&
+                images[selectedImageIndex]?.media !== null &&
+                (isVideo(images[selectedImageIndex].media) ? (
+                  // Video modal with controls
+                  <video
+                    className="max-h-[85vh] max-w-full object-contain rounded-lg shadow-2xl"
+                    controls
+                    autoPlay
+                    playsInline
+                  >
+                    <source
+                      src={
+                        typeof images[selectedImageIndex]?.media === 'object' &&
+                        images[selectedImageIndex]?.media?.url
+                          ? images[selectedImageIndex].media.url
+                          : ''
+                      }
+                    />
+                  </video>
+                ) : (
+                  // Image modal
+                  <Media
+                    resource={images[selectedImageIndex].media}
+                    imgClassName="max-h-[85vh] max-w-full object-contain rounded-lg shadow-2xl"
+                  />
+                ))}
+
+              {/* Caption */}
+              {images[selectedImageIndex]?.caption && (
+                <div className="absolute bottom-0 left-0 right-0 bg-gradient-to-t from-black/80 to-transparent p-6 text-white rounded-b-lg">
+                  <p className="text-center text-lg">{images[selectedImageIndex].caption}</p>
+                </div>
+              )}
+            </div>
+
+            {/* Image Counter */}
+            {images && images.length > 1 && (
+              <div className="absolute -bottom-12 left-1/2 -translate-x-1/2 text-white text-sm bg-black/50 px-3 py-1 rounded-full">
+                {selectedImageIndex + 1} / {images.length}
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+    </>
+  )
+}

--- a/src/blocks/Gallery/config.ts
+++ b/src/blocks/Gallery/config.ts
@@ -1,0 +1,34 @@
+import type { Block } from 'payload'
+
+export const Gallery: Block = {
+  slug: 'gallery',
+  interfaceName: 'Gallery',
+  fields: [
+    {
+      name: 'title',
+      type: 'text',
+      label: 'Gallery Title',
+      defaultValue: 'Our Gallery',
+    },
+    {
+      name: 'images',
+      type: 'array',
+      label: 'Gallery Images',
+      minRows: 1,
+      fields: [
+        {
+          name: 'media',
+          type: 'upload',
+          relationTo: 'media',
+          required: true,
+          label: 'Image or Video',
+        },
+        {
+          name: 'caption',
+          type: 'text',
+          label: 'Image Caption',
+        },
+      ],
+    },
+  ],
+}

--- a/src/blocks/RenderBlocks.tsx
+++ b/src/blocks/RenderBlocks.tsx
@@ -6,6 +6,7 @@ import { ArchiveBlock } from '@/blocks/ArchiveBlock/Component'
 import { CallToActionBlock } from '@/blocks/CallToAction/Component'
 import { ContentBlock } from '@/blocks/Content/Component'
 import { FormBlock } from '@/blocks/Form/Component'
+import { Gallery } from '@/blocks/Gallery/Component'
 import { MediaBlock } from '@/blocks/MediaBlock/Component'
 
 const blockComponents = {
@@ -13,6 +14,7 @@ const blockComponents = {
   content: ContentBlock,
   cta: CallToActionBlock,
   formBlock: FormBlock,
+  gallery: Gallery,
   mediaBlock: MediaBlock,
 }
 

--- a/src/collections/Pages/index.ts
+++ b/src/collections/Pages/index.ts
@@ -6,6 +6,7 @@ import { Archive } from '../../blocks/ArchiveBlock/config'
 import { CallToAction } from '../../blocks/CallToAction/config'
 import { Content } from '../../blocks/Content/config'
 import { FormBlock } from '../../blocks/Form/config'
+import { Gallery } from '../../blocks/Gallery/config'
 import { MediaBlock } from '../../blocks/MediaBlock/config'
 import { hero } from '@/heros/config'
 import { slugField } from '@/fields/slug'
@@ -75,7 +76,7 @@ export const Pages: CollectionConfig<'pages'> = {
             {
               name: 'layout',
               type: 'blocks',
-              blocks: [CallToAction, Content, MediaBlock, Archive, FormBlock],
+              blocks: [CallToAction, Content, MediaBlock, Archive, FormBlock, Gallery],
               required: true,
               admin: {
                 initCollapsed: true,

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -196,7 +196,7 @@ export interface Page {
       | null;
     media?: (string | null) | Media;
   };
-  layout: (CallToActionBlock | ContentBlock | MediaBlock | ArchiveBlock | FormBlock)[];
+  layout: (CallToActionBlock | ContentBlock | MediaBlock | ArchiveBlock | FormBlock | Gallery)[];
   meta?: {
     title?: string | null;
     /**
@@ -741,6 +741,23 @@ export interface Form {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "Gallery".
+ */
+export interface Gallery {
+  title?: string | null;
+  images?:
+    | {
+        media: string | Media;
+        caption?: string | null;
+        id?: string | null;
+      }[]
+    | null;
+  id?: string | null;
+  blockName?: string | null;
+  blockType: 'gallery';
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "redirects".
  */
 export interface Redirect {
@@ -1037,6 +1054,7 @@ export interface PagesSelect<T extends boolean = true> {
         mediaBlock?: T | MediaBlockSelect<T>;
         archive?: T | ArchiveBlockSelect<T>;
         formBlock?: T | FormBlockSelect<T>;
+        gallery?: T | GallerySelect<T>;
       };
   meta?:
     | T
@@ -1133,6 +1151,22 @@ export interface FormBlockSelect<T extends boolean = true> {
   form?: T;
   enableIntro?: T;
   introContent?: T;
+  id?: T;
+  blockName?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "Gallery_select".
+ */
+export interface GallerySelect<T extends boolean = true> {
+  title?: T;
+  images?:
+    | T
+    | {
+        media?: T;
+        caption?: T;
+        id?: T;
+      };
   id?: T;
   blockName?: T;
 }


### PR DESCRIPTION
https://github.com/stevensblueprint/genxl-cms/issues/5

- gallery layout block
- allows images and video
- media container size is scaled to original dimensions unlike current website, which has static 8 image galleries.
- changed default bg color to white

<img width="1920" height="761" alt="image" src="https://github.com/user-attachments/assets/fcf9e229-d22d-4341-aac0-03fe06a97cbb" />


<img width="1920" height="995" alt="image" src="https://github.com/user-attachments/assets/fd262c45-f3fe-43d6-aed8-d194caa31352" />
