### PR TITLE
feat: added course card

### DIFF
--- a/src/blocks/RenderBlocks.tsx
+++ b/src/blocks/RenderBlocks.tsx
@@ -9,6 +9,7 @@ import { FormBlock } from '@/blocks/Form/Component'
 import { Gallery } from '@/blocks/Gallery/Component'
 import { MediaBlock } from '@/blocks/MediaBlock/Component'
 import { SponsorsPartnersBlock } from '@/blocks/SponsorsPartners/Component'
+import { CourseCardBlock } from '@/blocks/CourseCard/Component'
 
 const blockComponents = {
   archive: ArchiveBlock,
@@ -18,6 +19,7 @@ const blockComponents = {
   gallery: Gallery,
   mediaBlock: MediaBlock,
   sponsorsPartners: SponsorsPartnersBlock,
+  courseCard: CourseCardBlock,
 }
 
 export const RenderBlocks: React.FC<{

--- a/src/collections/Pages/index.ts
+++ b/src/collections/Pages/index.ts
@@ -14,6 +14,7 @@ import { populatePublishedAt } from '../../hooks/populatePublishedAt'
 import { generatePreviewPath } from '../../utilities/generatePreviewPath'
 import { revalidateDelete, revalidatePage } from './hooks/revalidatePage'
 import { SponsorsPartners } from '../../blocks/SponsorsPartners/config'
+import { CourseCard } from '../../blocks/CourseCard/config'
 
 import {
   MetaDescriptionField,
@@ -77,7 +78,16 @@ export const Pages: CollectionConfig<'pages'> = {
             {
               name: 'layout',
               type: 'blocks',
-              blocks: [CallToAction, Content, MediaBlock, Archive, FormBlock, Gallery, SponsorsPartners],
+              blocks: [
+                CallToAction,
+                Content,
+                MediaBlock,
+                Archive,
+                FormBlock,
+                Gallery,
+                SponsorsPartners,
+                CourseCard,
+              ],
 
               required: true,
               admin: {

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -200,11 +200,11 @@ export interface Page {
   };
   layout: (
     | CallToActionBlock
-    | Gallery
     | ContentBlock
     | MediaBlock
     | ArchiveBlock
     | FormBlock
+    | Gallery
     | {
         sponsors?: {
           heading?: string | null;
@@ -233,6 +233,21 @@ export interface Page {
         id?: string | null;
         blockName?: string | null;
         blockType: 'sponsorsPartners';
+      }
+    | {
+        image: string | Media;
+        title: string;
+        grade: string;
+        duration: string;
+        classSize: string;
+        buttonLabel: string;
+        /**
+         * Paste a URL or a site-relative slug like /courses/scratch
+         */
+        buttonHref?: string | null;
+        id?: string | null;
+        blockName?: string | null;
+        blockType: 'courseCard';
       }
   )[];
   meta?: {
@@ -1092,6 +1107,7 @@ export interface PagesSelect<T extends boolean = true> {
         mediaBlock?: T | MediaBlockSelect<T>;
         archive?: T | ArchiveBlockSelect<T>;
         formBlock?: T | FormBlockSelect<T>;
+        gallery?: T | GallerySelect<T>;
         sponsorsPartners?:
           | T
           | {
@@ -1126,7 +1142,19 @@ export interface PagesSelect<T extends boolean = true> {
               id?: T;
               blockName?: T;
             };
-        gallery?: T | GallerySelect<T>;
+        courseCard?:
+          | T
+          | {
+              image?: T;
+              title?: T;
+              grade?: T;
+              duration?: T;
+              classSize?: T;
+              buttonLabel?: T;
+              buttonHref?: T;
+              id?: T;
+              blockName?: T;
+            };
       };
   meta?:
     | T


### PR DESCRIPTION
<img width="426" height="627" alt="Screenshot 2025-10-02 at 6 59 17 PM" src="https://github.com/user-attachments/assets/95fae0ce-b7be-4daf-91e0-679ecc4ef878" />
Above shows a card that can be added to a page to resolve issue #40 . The user can set grade, duration, class size, an image, and then a button is linked to the information page for each course. Below is the admin dashboard 
<img width="848" height="914" alt="Screenshot 2025-10-02 at 6 59 54 PM" src="https://github.com/user-attachments/assets/e30a34dd-54f8-4625-86c4-67ec5c060120" />
