### PR TITLE
feat/map-block

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "embla-carousel-react": "^8.6.0",
     "geist": "^1.3.0",
     "graphql": "^16.8.2",
+    "leaflet": "1.9.4",
     "lucide-react": "^0.378.0",
     "next": "15.4.4",
     "next-sitemap": "^4.2.3",
@@ -53,6 +54,7 @@
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "react-hook-form": "7.45.4",
+    "react-leaflet": "5.0.0",
     "sharp": "0.34.2",
     "tailwind-merge": "^2.3.0",
     "tailwindcss-animate": "^1.0.7"
@@ -61,6 +63,7 @@
     "@eslint/eslintrc": "^3.2.0",
     "@playwright/test": "1.54.1",
     "@tailwindcss/typography": "^0.5.13",
+    "@types/leaflet": "1.9.21",
     "@testing-library/react": "16.3.0",
     "@types/escape-html": "^1.0.2",
     "@types/node": "22.5.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,6 +77,9 @@ importers:
       graphql:
         specifier: ^16.8.2
         version: 16.11.0
+      leaflet:
+        specifier: 1.9.4
+        version: 1.9.4
       lucide-react:
         specifier: ^0.378.0
         version: 0.378.0(react@19.1.0)
@@ -101,6 +104,9 @@ importers:
       react-hook-form:
         specifier: 7.45.4
         version: 7.45.4(react@19.1.0)
+      react-leaflet:
+        specifier: 5.0.0
+        version: 5.0.0(leaflet@1.9.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       sharp:
         specifier: 0.34.2
         version: 0.34.2
@@ -126,6 +132,9 @@ importers:
       '@types/escape-html':
         specifier: ^1.0.2
         version: 1.0.4
+      '@types/leaflet':
+        specifier: 1.9.21
+        version: 1.9.21
       '@types/node':
         specifier: 22.5.4
         version: 22.5.4
@@ -1785,6 +1794,13 @@ packages:
   '@radix-ui/rect@1.1.1':
     resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
 
+  '@react-leaflet/core@3.0.0':
+    resolution: {integrity: sha512-3EWmekh4Nz+pGcr+xjf0KNyYfC3U2JjnkWsh0zcqaexYqmmB5ZhH37kz41JXGmKzpaMZCnPofBBm64i+YrEvGQ==}
+    peerDependencies:
+      leaflet: ^1.9.0
+      react: ^19.0.0
+      react-dom: ^19.0.0
+
   '@rolldown/pluginutils@1.0.0-beta.11':
     resolution: {integrity: sha512-L/gAA/hyCSuzTF1ftlzUSI/IKr2POHsv1Dd78GfqkR83KMNuswWD61JxGV2L7nRwBBBSDr6R1gCkdTmoN7W4ag==}
 
@@ -2183,6 +2199,9 @@ packages:
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
+  '@types/geojson@7946.0.16':
+    resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
+
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
 
@@ -2191,6 +2210,9 @@ packages:
 
   '@types/json5@0.0.29':
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
+
+  '@types/leaflet@1.9.21':
+    resolution: {integrity: sha512-TbAd9DaPGSnzp6QvtYngntMZgcRk+igFELwR2N99XZn7RXUdKgsXMR+28bUO0rPsWp8MIu/f47luLIQuSLYv/w==}
 
   '@types/lodash@4.17.20':
     resolution: {integrity: sha512-H3MHACvFUEiujabxhaI/ImO6gUrd8oOurg7LQtS7mbwIXA/cUqWrvBsaeJ23aZEPk1TAYkurjfMbSELfoCXlGA==}
@@ -3665,6 +3687,9 @@ packages:
     resolution: {integrity: sha512-MbjN408fEndfiQXbFQ1vnd+1NoLDsnQW41410oQBXiyXDMYH5z505juWa4KUE1LqxRC7DgOgZDbKLxHIwm27hA==}
     engines: {node: '>=0.10'}
 
+  leaflet@1.9.4:
+    resolution: {integrity: sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==}
+
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
@@ -4294,6 +4319,13 @@ packages:
 
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
+
+  react-leaflet@5.0.0:
+    resolution: {integrity: sha512-CWbTpr5vcHw5bt9i4zSlPEVQdTVcML390TjeDG0cK59z1ylexpqC6M1PJFjV8jD7CF+ACBFsLIDs6DRMoLEofw==}
+    peerDependencies:
+      leaflet: ^1.9.0
+      react: ^19.0.0
+      react-dom: ^19.0.0
 
   react-refresh@0.17.0:
     resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
@@ -7123,6 +7155,12 @@ snapshots:
 
   '@radix-ui/rect@1.1.1': {}
 
+  '@react-leaflet/core@3.0.0(leaflet@1.9.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      leaflet: 1.9.4
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+
   '@rolldown/pluginutils@1.0.0-beta.11': {}
 
   '@rollup/rollup-android-arm-eabi@4.50.1':
@@ -7617,6 +7655,8 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
+  '@types/geojson@7946.0.16': {}
+
   '@types/hast@3.0.4':
     dependencies:
       '@types/unist': 3.0.3
@@ -7624,6 +7664,10 @@ snapshots:
   '@types/json-schema@7.0.15': {}
 
   '@types/json5@0.0.29': {}
+
+  '@types/leaflet@1.9.21':
+    dependencies:
+      '@types/geojson': 7946.0.16
 
   '@types/lodash@4.17.20': {}
 
@@ -9308,6 +9352,8 @@ snapshots:
     dependencies:
       language-subtag-registry: 0.3.23
 
+  leaflet@1.9.4: {}
+
   levn@0.4.1:
     dependencies:
       prelude-ls: 1.2.1
@@ -10078,6 +10124,13 @@ snapshots:
   react-is@16.13.1: {}
 
   react-is@17.0.2: {}
+
+  react-leaflet@5.0.0(leaflet@1.9.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+    dependencies:
+      '@react-leaflet/core': 3.0.0(leaflet@1.9.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      leaflet: 1.9.4
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
 
   react-refresh@0.17.0: {}
 

--- a/src/blocks/Map/Component.tsx
+++ b/src/blocks/Map/Component.tsx
@@ -1,0 +1,70 @@
+'use client'
+
+import React from 'react'
+import dynamic from 'next/dynamic'
+
+import type { Map as MapProps } from '@/payload-types'
+
+// Dynamically import the entire map to avoid SSR issues
+const DynamicMap = dynamic(() => import('./MapView'), {
+  ssr: false,
+  loading: () => (
+    <div className="w-full h-full flex items-center justify-center bg-gray-100">
+      <div className="text-gray-500">Loading map...</div>
+    </div>
+  ),
+})
+
+type Props = MapProps & {
+  className?: string
+  enableGutter?: boolean
+  disableInnerContainer?: boolean
+}
+
+export const Map: React.FC<Props> = (props) => {
+  const { title, description, locations, defaultZoom = 2, defaultCenter, className } = props
+
+  // Calculate center from locations if not provided
+  const centerLat = defaultCenter?.latitude ?? 20
+  const centerLng = defaultCenter?.longitude ?? 0
+
+  // Ensure we have locations
+  if (!locations || locations.length === 0) {
+    return (
+      <div className={`container mx-auto px-4 py-8 ${className || ''}`}>
+        <div className="text-center text-gray-500">No locations to display on the map.</div>
+      </div>
+    )
+  }
+
+  // Filter valid locations
+  const validLocations = locations.filter(
+    (loc) =>
+      loc &&
+      typeof loc.latitude === 'number' &&
+      typeof loc.longitude === 'number' &&
+      !isNaN(loc.latitude) &&
+      !isNaN(loc.longitude),
+  )
+
+  return (
+    <div className={`container mx-auto px-4 py-8 lg:py-16 ${className || ''}`}>
+      <div className="max-w-7xl mx-auto">
+        {title && (
+          <h2 className="text-3xl lg:text-4xl font-bold text-gray-900 mb-4 text-center">{title}</h2>
+        )}
+        {description && (
+          <p className="text-lg text-gray-700 mb-8 text-center max-w-3xl mx-auto">{description}</p>
+        )}
+        <div className="w-full h-[500px] lg:h-[600px] rounded-lg overflow-hidden shadow-lg border border-gray-200">
+          <DynamicMap
+            locations={validLocations}
+            defaultZoom={defaultZoom}
+            centerLat={centerLat}
+            centerLng={centerLng}
+          />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/blocks/Map/MapView.tsx
+++ b/src/blocks/Map/MapView.tsx
@@ -1,0 +1,69 @@
+'use client'
+
+import React from 'react'
+import { MapContainer, TileLayer, Marker, Popup } from 'react-leaflet'
+import L from 'leaflet'
+import 'leaflet/dist/leaflet.css'
+
+// Fix for default marker icon in Next.js
+if (typeof window !== 'undefined') {
+  delete (L.Icon.Default.prototype as any)._getIconUrl
+  L.Icon.Default.mergeOptions({
+    iconRetinaUrl: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/images/marker-icon-2x.png',
+    iconUrl: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/images/marker-icon.png',
+    shadowUrl: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/images/marker-shadow.png',
+  })
+}
+
+type MapViewProps = {
+  locations: Array<{
+    name: string
+    latitude: number
+    longitude: number
+    description?: string | null
+  }>
+  defaultZoom: number
+  centerLat: number
+  centerLng: number
+}
+
+const MapView: React.FC<MapViewProps> = ({ locations, defaultZoom, centerLat, centerLng }) => {
+  return (
+    <MapContainer
+      center={[centerLat, centerLng]}
+      zoom={defaultZoom}
+      style={{ height: '100%', width: '100%' }}
+      scrollWheelZoom={true}
+    >
+      <TileLayer
+        attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+        url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+      />
+      {locations.map((location, index) => {
+        if (
+          !location.latitude ||
+          !location.longitude ||
+          typeof location.latitude !== 'number' ||
+          typeof location.longitude !== 'number'
+        ) {
+          return null
+        }
+
+        return (
+          <Marker key={index} position={[location.latitude, location.longitude]}>
+            <Popup>
+              <div className="p-2">
+                <h3 className="font-bold text-lg mb-1">{location.name}</h3>
+                {location.description && (
+                  <p className="text-sm text-gray-600">{location.description}</p>
+                )}
+              </div>
+            </Popup>
+          </Marker>
+        )
+      })}
+    </MapContainer>
+  )
+}
+
+export default MapView

--- a/src/blocks/Map/config.ts
+++ b/src/blocks/Map/config.ts
@@ -1,0 +1,106 @@
+import type { Block } from 'payload'
+
+export const Map: Block = {
+  slug: 'map',
+  interfaceName: 'Map',
+  fields: [
+    {
+      name: 'title',
+      type: 'text',
+      label: 'Map Title',
+      defaultValue: 'Our Outreach Locations',
+    },
+    {
+      name: 'description',
+      type: 'textarea',
+      label: 'Map Description',
+      admin: {
+        description: 'Optional description to display above the map',
+      },
+    },
+    {
+      name: 'locations',
+      type: 'array',
+      label: 'Locations',
+      minRows: 1,
+      required: true,
+      fields: [
+        {
+          name: 'name',
+          type: 'text',
+          label: 'Location Name',
+          required: true,
+          admin: {
+            description: 'e.g., "Kathmandu, Nepal"',
+          },
+        },
+        {
+          name: 'latitude',
+          type: 'number',
+          label: 'Latitude',
+          required: true,
+          admin: {
+            description: 'Location latitude (e.g., 27.7172)',
+            step: 0.0001,
+          },
+        },
+        {
+          name: 'longitude',
+          type: 'number',
+          label: 'Longitude',
+          required: true,
+          admin: {
+            description: 'Location longitude (e.g., 85.3240)',
+            step: 0.0001,
+          },
+        },
+        {
+          name: 'description',
+          type: 'textarea',
+          label: 'Location Description',
+          admin: {
+            description: 'Optional description shown in the popup',
+          },
+        },
+      ],
+    },
+    {
+      name: 'defaultZoom',
+      type: 'number',
+      label: 'Default Zoom Level',
+      defaultValue: 2,
+      admin: {
+        description: 'Zoom level when map first loads (1-18, where 1 is world view)',
+      },
+      min: 1,
+      max: 18,
+    },
+    {
+      name: 'defaultCenter',
+      type: 'group',
+      label: 'Default Map Center',
+      fields: [
+        {
+          name: 'latitude',
+          type: 'number',
+          label: 'Center Latitude',
+          defaultValue: 20,
+          admin: {
+            description: 'Default center latitude for the map',
+            step: 0.0001,
+          },
+        },
+        {
+          name: 'longitude',
+          type: 'number',
+          label: 'Center Longitude',
+          defaultValue: 0,
+          admin: {
+            description: 'Default center longitude for the map',
+            step: 0.0001,
+          },
+        },
+      ],
+    },
+  ],
+}

--- a/src/blocks/RenderBlocks.tsx
+++ b/src/blocks/RenderBlocks.tsx
@@ -16,6 +16,7 @@ import { CarouselBlock } from '@/blocks/Carousel/Component'
 import { NumbersBlock } from '@/blocks/NumbersBlock/Component'
 import { NumbersBlockMobile } from '@/blocks/NumbersBlockMobile/Component'
 import { MeatballMenuBlock } from '@/blocks/MeatballMenu/Component'
+import { Map } from '@/blocks/Map/Component'
 
 const blockComponents = {
   archive: ArchiveBlock,
@@ -32,6 +33,7 @@ const blockComponents = {
   numbersBlock: NumbersBlock,
   numbersBlockMobile: NumbersBlockMobile,
   meatballMenu: MeatballMenuBlock,
+  map: Map,
 }
 
 export const RenderBlocks: React.FC<{

--- a/src/collections/Pages/index.ts
+++ b/src/collections/Pages/index.ts
@@ -21,6 +21,7 @@ import { Carousel } from '../../blocks/Carousel/config'
 import { NumbersBlock } from '../../blocks/NumbersBlock/config'
 import { NumbersBlockMobile } from '../../blocks/NumbersBlockMobile/config'
 import { MeatballMenu } from '../../blocks/MeatballMenu/config'
+import { Map } from '../../blocks/Map/config'
 
 import {
   MetaDescriptionField,
@@ -99,6 +100,7 @@ export const Pages: CollectionConfig<'pages'> = {
                 NumbersBlock,
                 NumbersBlockMobile,
                 MeatballMenu,
+                Map,
               ],
 
               required: true,

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -296,6 +296,7 @@ export interface Page {
     | NumbersBlock
     | NumbersBlockMobile
     | MeatballMenuBlock
+    | Map
   )[];
   meta?: {
     title?: string | null;
@@ -911,6 +912,9 @@ export interface NumbersBlockMobile {
   id?: string | null;
   blockName?: string | null;
   blockType: 'numbersBlockMobile';
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "MeatballMenuBlock".
  */
 export interface MeatballMenuBlock {
@@ -931,6 +935,53 @@ export interface MeatballMenuBlock {
   id?: string | null;
   blockName?: string | null;
   blockType: 'meatballMenu';
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "Map".
+ */
+export interface Map {
+  title?: string | null;
+  /**
+   * Optional description to display above the map
+   */
+  description?: string | null;
+  locations: {
+    /**
+     * e.g., "Kathmandu, Nepal"
+     */
+    name: string;
+    /**
+     * Location latitude (e.g., 27.7172)
+     */
+    latitude: number;
+    /**
+     * Location longitude (e.g., 85.3240)
+     */
+    longitude: number;
+    /**
+     * Optional description shown in the popup
+     */
+    description?: string | null;
+    id?: string | null;
+  }[];
+  /**
+   * Zoom level when map first loads (1-18, where 1 is world view)
+   */
+  defaultZoom?: number | null;
+  defaultCenter?: {
+    /**
+     * Default center latitude for the map
+     */
+    latitude?: number | null;
+    /**
+     * Default center longitude for the map
+     */
+    longitude?: number | null;
+  };
+  id?: string | null;
+  blockName?: string | null;
+  blockType: 'map';
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -1316,6 +1367,7 @@ export interface PagesSelect<T extends boolean = true> {
         numbersBlock?: T | NumbersBlockSelect<T>;
         numbersBlockMobile?: T | NumbersBlockMobileSelect<T>;
         meatballMenu?: T | MeatballMenuBlockSelect<T>;
+        map?: T | MapSelect<T>;
       };
   meta?:
     | T
@@ -1484,6 +1536,11 @@ export interface NumbersBlockMobileSelect<T extends boolean = true> {
   applicants?: T;
   countriesStates?: T;
   instructors?: T;
+  id?: T;
+  blockName?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "MeatballMenuBlock_select".
  */
 export interface MeatballMenuBlockSelect<T extends boolean = true> {
@@ -1497,6 +1554,32 @@ export interface MeatballMenuBlockSelect<T extends boolean = true> {
         caption?: T;
         subcaption?: T;
         id?: T;
+      };
+  id?: T;
+  blockName?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "Map_select".
+ */
+export interface MapSelect<T extends boolean = true> {
+  title?: T;
+  description?: T;
+  locations?:
+    | T
+    | {
+        name?: T;
+        latitude?: T;
+        longitude?: T;
+        description?: T;
+        id?: T;
+      };
+  defaultZoom?: T;
+  defaultCenter?:
+    | T
+    | {
+        latitude?: T;
+        longitude?: T;
       };
   id?: T;
   blockName?: T;


### PR DESCRIPTION
- added leaflet to modules
<img width="1376" height="728" alt="image" src="https://github.com/user-attachments/assets/63707d4b-e5b7-418a-aa32-30ffab60a8e9" />
<img width="320" height="564" alt="image" src="https://github.com/user-attachments/assets/1380d2f8-81ed-4ff5-9471-d53ff24fcb2f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new Map block for content pages enabling interactive location mapping
  * Create multiple location markers with customizable titles and optional descriptions
  * Configure default zoom levels and center coordinates to focus maps on specific regions
  * Location popups display names and details when markers are selected

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->