### PR TITLE
fix/about page padding

### DIFF
--- a/src/blocks/MeatballMenu/Component.tsx
+++ b/src/blocks/MeatballMenu/Component.tsx
@@ -15,17 +15,24 @@ type Props = {
   subtitle?: string | null
   backgroundColor?: string | null
   items?: MeatballMenuItem[] | null
+  isLast?: boolean
 }
 
-export const MeatballMenuBlock: React.FC<Props> = ({ title, subtitle, backgroundColor, items }) => {
+export const MeatballMenuBlock: React.FC<Props> = ({
+  title,
+  subtitle,
+  backgroundColor,
+  items,
+  isLast,
+}) => {
   const bgStyle = backgroundColor ? { backgroundColor } : undefined
 
   return (
-    <section className="my-16 py-16" style={bgStyle}>
+    <section className={`py-20 lg:py-24 -mt-20 ${isLast ? '-mb-24' : '-mb-16'}`} style={bgStyle}>
       <div className="container mx-auto max-w-6xl">
         {/* Header Section */}
         {title && (
-          <h2 className="text-center text-3xl md:text-4xl font-bold tracking-tight mb-2 text-black">
+          <h2 className="text-center text-4xl md:text-5xl lg:text-6xl font-bold tracking-tight mb-2 text-black">
             {title}
           </h2>
         )}

--- a/src/blocks/RenderBlocks.tsx
+++ b/src/blocks/RenderBlocks.tsx
@@ -55,9 +55,14 @@ export const RenderBlocks: React.FC<{
             const Block = blockComponents[blockType] as React.ComponentType<any>
 
             if (Block) {
+              const isLastBlock = index === blocks.length - 1
+              const isMeatballMenu = blockType === 'meatballMenu'
+              // Remove bottom margin for last meatballMenu block to eliminate whitespace before footer
+              const wrapperClass = isLastBlock && isMeatballMenu ? 'mt-16 mb-0' : 'my-16'
+
               return (
-                <div className="my-16" key={index}>
-                  <Block {...block} disableInnerContainer />
+                <div className={wrapperClass} key={index}>
+                  <Block {...block} disableInnerContainer isLast={isLastBlock && isMeatballMenu} />
                 </div>
               )
             }

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -926,7 +926,6 @@ export interface NumbersBlockMobile {
   blockName?: string | null;
   blockType: 'numbersBlockMobile';
 }
-
 /**
  * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "MeatballMenuBlock".
@@ -1569,8 +1568,6 @@ export interface NumbersBlockMobileSelect<T extends boolean = true> {
   id?: T;
   blockName?: T;
 }
-
-
 /**
  * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "MeatballMenuBlock_select".


### PR DESCRIPTION
- fix white space on about page

<img width="1912" height="1341" alt="image" src="https://github.com/user-attachments/assets/077091df-3d0b-43d9-87b3-583d2d3a4445" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Enhanced heading typography with improved responsive scaling in the Meatball Menu section for better visual hierarchy across all screen sizes.
  * Optimized spacing and margins throughout block layouts with responsive adjustments to improve visual consistency and alignment, particularly for trailing sections.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->