### PR TITLE
remove padding

### DIFF
--- a/src/blocks/ContactFormBlock/Component.tsx
+++ b/src/blocks/ContactFormBlock/Component.tsx
@@ -13,7 +13,7 @@ export const ContactFormBlock: React.FC<Props> = ({
 }) => {
   return (
     <section className="w-full bg-white">
-      <div className="container py-16 md:py-20">
+      <div className="container py-0 md:py-0">
         <div className="max-w-2xl mx-auto">
           {contactHeading && (
             <h2 className="text-2xl md:text-3xl font-semibold tracking-tight text-center">

--- a/src/blocks/VolunteerRolesBlock/Component.tsx
+++ b/src/blocks/VolunteerRolesBlock/Component.tsx
@@ -35,7 +35,7 @@ export const VolunteerRolesBlock: React.FC<Props> = ({
 
   return (
     <section className="w-full bg-white">
-      <div className="container py-16 md:py-20">
+      <div className="container py-0 md:py-0">
         {rolesHeading && (
           <h2 className="text-2xl md:text-3xl font-semibold tracking-tight text-center mb-10">
             {rolesHeading}


### PR DESCRIPTION
just removed padding to make it like spec
<img width="1999" height="1080" alt="image" src="https://github.com/user-attachments/assets/28552692-0a54-49b8-9edf-38664f30549b" />
<img width="1961" height="1080" alt="image" src="https://github.com/user-attachments/assets/c1186901-0238-4e1e-a12c-5955086ceb8d" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Removed vertical padding from the contact form section to reduce excess whitespace and improve layout efficiency.
  * Adjusted vertical spacing on the volunteer roles section for a more compact visual presentation across all screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->